### PR TITLE
Check if TrafficSystem is instanced before using it

### DIFF
--- a/Assets/SimpleTraffic/Scripts/NavConnection.cs
+++ b/Assets/SimpleTraffic/Scripts/NavConnection.cs
@@ -37,7 +37,7 @@ namespace Kawaiiju.Traffic
 
 		private void OnDrawGizmos()
 		{
-			if(TrafficSystem.Instance.drawGizmos)
+			if(TrafficSystem.Instance != null && TrafficSystem.Instance.drawGizmos)
 			{
 				Gizmos.color = Color.white;
 				Gizmos.DrawSphere(transform.position - new Vector3(0, transform.localScale.y * 0.5f, 0), 0.05f);


### PR DESCRIPTION
If you try to edit the prefabs in an empty scene, all of them will throw exceptions because TrafficSystem is not present.